### PR TITLE
 Add null provider to support the privacy API

### DIFF
--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -1,0 +1,13 @@
+<?php
+namespace block_equella_search\privacy;
+
+class provider implements \core_privacy\local\metadata\null_provider {
+    //this plugin does not store any personal user data.
+    /**
+     * Get the language string identifier with the component's language
+     * file to explain why this plugin stores no data.
+     */
+    public static function get_reason(): string {
+        return 'privacy:metadata';
+    }
+}

--- a/lang/en/block_equella_search.php
+++ b/lang/en/block_equella_search.php
@@ -42,4 +42,4 @@ $string['tryequella'] = '<p>Can\'t find what you\'re looking for?  Try <a href="
 $string['equella_search:addinstance'] = 'Add openEQUELLA search block';
 $string['equella_search:view'] = 'View openEQUELLA search block';
 $string['block/equella_search:search'] = 'Search in openEQUELLA';
-$string['privacy:metadata'] = "The SEARCH block does not store any data - it uses shared secret to interact with openEQUELLA.";
+$string['privacy:metadata'] = 'This block does not store any data - it uses a shared secret to interact with openEQUELLA';

--- a/lang/en/block_equella_search.php
+++ b/lang/en/block_equella_search.php
@@ -42,4 +42,4 @@ $string['tryequella'] = '<p>Can\'t find what you\'re looking for?  Try <a href="
 $string['equella_search:addinstance'] = 'Add openEQUELLA search block';
 $string['equella_search:view'] = 'View openEQUELLA search block';
 $string['block/equella_search:search'] = 'Search in openEQUELLA';
-$string['privacy:metadata'] = 'This block does not store any data - it uses a shared secret to interact with openEQUELLA';
+$string['privacy:metadata'] = 'This block does not store any data.';

--- a/lang/en/block_equella_search.php
+++ b/lang/en/block_equella_search.php
@@ -42,3 +42,4 @@ $string['tryequella'] = '<p>Can\'t find what you\'re looking for?  Try <a href="
 $string['equella_search:addinstance'] = 'Add openEQUELLA search block';
 $string['equella_search:view'] = 'View openEQUELLA search block';
 $string['block/equella_search:search'] = 'Search in openEQUELLA';
+$string['privacy:metadata'] = "The SEARCH block does not store any data - it uses shared secret to interact with openEQUELLA.";

--- a/version.php
+++ b/version.php
@@ -24,8 +24,9 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2011012803;        // The current plugin version (Date: YYYYMMDDXX)
+$plugin->version   = 2020083100;             // The current plugin version (Date: YYYYMMDDXX)
 $plugin->component = 'block_equella_search'; // Full name of the plugin (used for diagnostics)
 $plugin->dependencies = array(
     'mod_equella' => 2015042000
 );
+$plugin->release = "1.0.0";


### PR DESCRIPTION
Moodle now adheres to the GDPR which means we need to implement a privacy provider. 
See https://docs.moodle.org/dev/Privacy_API#Plugins_which_do_not_store_personal_data for details.  

![image](https://user-images.githubusercontent.com/24543345/91247543-d7823700-e795-11ea-8da0-036e3d89578a.png)
