### PR TITLE
fix icon URL

### DIFF
--- a/block_equella_search.php
+++ b/block_equella_search.php
@@ -77,7 +77,7 @@ class block_equella_search extends block_list {
         if ($course->id !== SITEID and has_capability('block/equella_search:search', $context)) {
             $equellasearchurl = new moodle_url('/blocks/equella_search/equella_search_api.php', array('courseid'=>$this->instance->pageid));
             $this->content->items[] = html_writer::link($equellasearchurl, get_string('searchaction', 'block_equella_search'));
-            $iconurl = new moodle_url('/mod/equella/pix/icon-red.gif');
+            $iconurl = new moodle_url('/mod/equella/pix/icon.png');
             $icon = html_writer::empty_tag('img', array('src' => $iconurl, 'class' => 'icon', 'alt' => 'equella-icon'));
             $this->content->icons[]= $icon;
         }


### PR DESCRIPTION
icon is in the main mod_openEQUELLA [pix directory](https://github.com/openequella/moodle-mod_openEQUELLA/tree/master/pix) but icon-red.gif no longer exists, this uses icon.png instead (though there is a .gif available, too). Theoretically, the link could still break if the versions of the two plugins don't align, but this makes sense for the current version to at least work together. Really, the search plugin should probably package its own image assets. Seems tricky either way you do it to ensure they always stay in sync.